### PR TITLE
Sort by updated time

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -133,18 +133,12 @@
         <div class="g2tt-menuitem-checkbox"></div>Show unread</div>
       </div>
       <div class="g2tt-menuseparator" style="-webkit-user-select: none;" role="separator" id="seperator4"></div>
-      <div class="g2tt-menuitem" role="menuitem" style="-webkit-user-select: none;" id="menu-unsubscribe">
-        <div class="g2tt-menuitem-content">Unsubscribe</div>
-      </div>
       <div class="g2tt-menuitem" role="menuitem" style="-webkit-user-select: none;" id="menu-logout">
         <div class="g2tt-menuitem-content">Logout</div>
       </div>
     </div>
   </div>
   <div id="feed" class="">
-    <div id="unsubscribe-message" class="hidden">
-      <p>Unsubscribing from this feed...</p>
-    </div>
     <div class="samedir">
       <div id="entries" class="mobilelist" style="visibility: visible;">
     <!-- Entries go here -->

--- a/js/g2tt.js
+++ b/js/g2tt.js
@@ -126,14 +126,13 @@ $(document).ready(function () {
     });
 
     // Back to Feeds
-    var backToFeeds = function () {
+    $('.back-to-feeds').unbind('click').click(function () {
         $('#feed').addClass('hidden');
         $('#subscriptions').removeClass('hidden');
         $('.back-to-feeds').addClass('hidden');
         $('.g2tt-menu').children().not('#seperator4, #menu-logout').toggle('hidden');
         getTopCategories();
-    };
-    $('.back-to-feeds').unbind('click').click(backToFeeds);
+    });
 
     // View mode feeds menu selection
     $('#feeds-' + pref_ViewMode).addClass('g2tt-option-selected');
@@ -165,20 +164,6 @@ $(document).ready(function () {
         request.done(function (response) {
             $('#entries').empty();
             getHeadlines();
-        });
-    });
-
-    // Unsubscribe
-    $('#menu-unsubscribe').unbind('click').click(function () {
-        $('#unsubscribe-message').removeClass('hidden');
-        var data = new Object();
-        data.op = "unsubscribeFeed";
-        data.feed_id = pref_Feed;
-        var request = apiCall(data);
-
-        request.done(function (response) {
-          $('#unsubscribe-message').addClass('hidden');
-          backToFeeds();
         });
     });
 


### PR DESCRIPTION
My feeds weren't actually displayed in order according to their updated time (for either "sort by newest" or "sort by oldest"). By adding some debug statements, I saw that the API was not returning them in any sorted order, despite being called with "date_reverse" or "feed_dates" as it expects.

So instead of debugging what's wrong with TT-RSS, writing a patch for it, and getting that approved in the main project, this workaround makes the mobile version sort it client-side.

(Sorry for the slightly messy branch history with the reverted commit from a different pull request.)
