### PR TITLE
Change ajax call to explicitly set application/json, more specific checks on login errors with a catchall for unknowns.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,10 @@ edit `js/g2tt-config.js` and change `global_ttrssUrl` (line 2) to point to the c
 If the webapp is installed in a subdirectory of TT-RSS, it could be wiped on an update to TT-RSS
 so after each update of TT-RSS, you may need to reinstall G2TTRSS.
 
-Use of this webapp requires TT-RSS's external APIs. They are enabled through TT-RSS's preferences:
- * in *Tiny Tiny RSS* go into `Actions` -> `Preferences`
- * `Configuration` -> `Enable external API`
+Use of this webapp requires TT-RSS's external APIs. They are enabled through the per-user TT-RSS's preferences:
+ * in *Tiny Tiny RSS* go into *Hamburger menu* -> `Preferences` -> `Preferences`
+ * `Configuration` -> `Enable API`
+ * `Configuration` -> `Allows accessing the API from browsers`
 
 
 Current features

--- a/js/g2tt.js
+++ b/js/g2tt.js
@@ -476,6 +476,7 @@ function apiCall(data, asynch) {
     data.sid = $.cookie('g2tt_sid');
     data = JSON.stringify(data);
     var request = $.ajax({
+        contentType: "application/json",
         url: global_ttrssUrl + "/api/",
         type: "post",
         dataType: "json",

--- a/js/g2tt.js
+++ b/js/g2tt.js
@@ -62,8 +62,11 @@ $(document).ready(function () {
              if (response['content'].error =='LOGIN_ERROR'){
                  window.alert("Username and/or Password were incorrect!");       
              }
-             if (response['content'].error =='API_DISABLED'){
-                 window.alert("The API Setting is disabled. Login on the desktop version and enable API in the Preferences.");       
+             if (response['content'].error =='API_DISABLED' || response['content'].error =='INCORRECT_USAGE'){
+                 window.alert("The API Settings are disabled. Login on the desktop version and enable both API settings in the Preferences.");
+             }
+             if (response['content'].error  !=q'' ){
+                 window.alert("Unexpected error received: ".concat(" ", response['content'].error));
              }
              else {
                  $.cookie('g2tt_sid', response['content'].session_id, {

--- a/js/g2tt.js
+++ b/js/g2tt.js
@@ -65,7 +65,7 @@ $(document).ready(function () {
              if (response['content'].error =='API_DISABLED' || response['content'].error =='INCORRECT_USAGE'){
                  window.alert("The API Settings are disabled. Login on the desktop version and enable both API settings in the Preferences.");
              }
-             if (response['content'].error  !=q'' ){
+             if (typeof response['content'].error  !=='undefined' ){
                  window.alert("Unexpected error received: ".concat(" ", response['content'].error));
              }
              else {


### PR DESCRIPTION
fixes issue described at https://github.com/tt-rss/tt-rss/issues/334, whereby API calls are subject to extra screening to prevent XSS issues.